### PR TITLE
Document Task 2 port fix in REPORT.md

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -287,3 +287,33 @@ This conversation demonstrates:
 4. Response is sent back through the WebSocket to the Flutter client
 
 ---
+
+## Task 2 Fix Applied
+
+### Issue Found and Fixed
+
+**Problem:** The autochecker test was failing with "FAIL: could not reach LLM — Connection refused"
+
+**Root Cause:** Port mismatch in `.env.docker.secret`:
+- `QWEN_CODE_API_HOST_PORT` was set to `42005`
+- But the qwen-code-api container was actually mapped to port `42006`
+
+**Fix Applied:** Updated `.env.docker.secret` to use correct port:
+```bash
+QWEN_CODE_API_HOST_PORT=42006  # Was 42005
+```
+
+**Verification:**
+```terminal
+$ curl -H "Authorization: Bearer my-secret-qwen-key" http://localhost:42006/v1/models
+{"object":"list","data":[
+  {"id":"qwen3-coder-plus"},
+  {"id":"qwen3-coder-flash"},
+  {"id":"coder-model"},
+  {"id":"vision-model"}
+]}
+```
+
+The LLM API is now reachable from the VM shell using the environment variables in `.env.docker.secret`.
+
+---


### PR DESCRIPTION
- Fixed QWEN_CODE_API_HOST_PORT from 42005 to 42006 in .env.docker.secret
- Autochecker was failing with 'Connection refused' due to wrong port
- LLM API now reachable from VM shell
- Added verification evidence to report

<!-- Provide a general summary of your changes in the Title above -->

## Summary

<!-- What does this PR do?

Replace <issue-number> with the number of the corresponding task issue.

Add more details if necessary.
-->

- Closes #<issue-number>

---

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [ ] I see `base: main` <- `compare: <branch>` above the PR title.
- [ ] I edited the line `- Closes #<issue-number>`.
- [ ] I wrote clear commit messages.
- [ ] I reviewed my own diff before requesting review.
- [ ] I understand the changes I’m submitting.
